### PR TITLE
Automatic patching of auxClasspath

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
-      <version>2.2.1</version>
+      <version>${lib.version.maven-project}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,6 +24,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>2.2.1</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/instrumentation/AbstractInstrumentationMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/instrumentation/AbstractInstrumentationMojo.java
@@ -170,7 +170,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractMojo {
      * https://github.com/cobertura/cobertura/blob/db3bedf3334d8f35bad7ca3c6f4d777be6a09fc5/cobertura/src/main/java/net/sourceforge/cobertura/instrument/CoberturaClassWriter.java#L32
      * 
      */
-    private void patchAuxClasspath() throws MojoExecutionException {
+    private void feedAuxClasspath() throws MojoExecutionException {
         List<URL> urls = new ArrayList<URL>();
         
         // Add the classes directory
@@ -199,7 +199,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractMojo {
                     throw new MojoExecutionException("An error occured during code instrumentation:", e);
                 }
             } else {
-                getLog().warn("No file fould for artifact " + artifactId);
+                getLog().warn("No file found for artifact " + artifactId);
             }
         }
         InstrumentMain.urlClassLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]));
@@ -207,7 +207,7 @@ public abstract class AbstractInstrumentationMojo extends AbstractMojo {
 
     private void processInstrumentation(final Arguments arguments) throws MojoExecutionException {
         getLog().debug("Instrumenting code with Cobertura");
-        patchAuxClasspath();
+        feedAuxClasspath();
         try {
             new Cobertura(arguments).instrumentCode()
                 .saveProjectData();

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/instrumentation/ITInstrumentationMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/instrumentation/ITInstrumentationMojo.java
@@ -21,13 +21,16 @@ package com.qualinsight.mojo.cobertura.core.instrumentation;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Mojo that instruments code to be tested by integration tests in order to be able to generate coverage report file for integration tests.
  *
  * @author Michel Pawlak
  */
-@Mojo(name = "instrument-it", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
+@Mojo(name = "instrument-it", 
+    defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, 
+    requiresDependencyResolution = ResolutionScope.COMPILE)
 public class ITInstrumentationMojo extends AbstractInstrumentationMojo {
 
 }

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/instrumentation/ITInstrumentationMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/instrumentation/ITInstrumentationMojo.java
@@ -28,9 +28,11 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  *
  * @author Michel Pawlak
  */
-@Mojo(name = "instrument-it", 
+@Mojo(
+    name = "instrument-it", 
     defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, 
-    requiresDependencyResolution = ResolutionScope.COMPILE)
+    requiresDependencyResolution = ResolutionScope.COMPILE
+)
 public class ITInstrumentationMojo extends AbstractInstrumentationMojo {
 
 }

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/instrumentation/UTInstrumentationMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/instrumentation/UTInstrumentationMojo.java
@@ -21,12 +21,17 @@ package com.qualinsight.mojo.cobertura.core.instrumentation;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Mojo that instruments code to be tested by unit tests in order to be able to generate coverage report file for unit tests.
  *
  * @author Michel Pawlak
  */
-@Mojo(name = "instrument-ut", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES)
+@Mojo(
+    name = "instrument-ut", 
+    defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES,
+    requiresDependencyResolution = ResolutionScope.COMPILE
+)
 public class UTInstrumentationMojo extends AbstractInstrumentationMojo {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <lib.version.maven-plugin-api>3.2.5</lib.version.maven-plugin-api>
     <lib.version.maven-plugin-annotations>3.4</lib.version.maven-plugin-annotations>
     <lib.version.commons-io>2.4</lib.version.commons-io>
+    <lib.version.maven-project>2.2.1</lib.version.maven-project>
     <!-- License properties -->
     <license.name>QualInsight-LGPL3</license.name>
     <license.project>qualinsight-mojo-cobertura</license.project>


### PR DESCRIPTION
We had some trouble with instrumentation and since we have no possibility to pass --auxClasspath per command line, I saw no other way than to do the patching in the instrumentation.

See:
 - https://github.com/cobertura/cobertura/wiki/FAQ#classnotfoundexception-during-instrumentation
 - https://github.com/cobertura/cobertura/issues/338
 - https://github.com/cobertura/cobertura/issues/231
  - https://github.com/cobertura/cobertura/issues/74
 - https://github.com/cobertura/cobertura/blob/db3bedf3334d8f35bad7ca3c6f4d777be6a09fc5/cobertura/src/main/java/net/sourceforge/cobertura/instrument/CoberturaClassWriter.java#L32
