### PR TITLE
Added a sourcesPaths array tag that will add multiple Sources to the …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,50 @@
+.DS_Store
+
+# Created by .ignore support plugin (hsz.mobi)
+### Eclipse template
+*.pydevproject
+.metadata
+.gradle
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+*.log
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# TeXlipse plugin
+.texlipse
+
+
+### Java template
 *.class
 
 # Mobile Tools for Java (J2ME)
@@ -11,15 +58,76 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-# maven
+
+### NetBeans template
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+.nb-gradle/
+
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+
+### Maven template
 target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
 
-# eclipse files
-.settings/
-.project
-.classpath
-bin/
 
-# MacOS X files
-.DS_Store
-/bin/

--- a/conversion/pom.xml
+++ b/conversion/pom.xml
@@ -10,4 +10,18 @@
   <packaging>jar</packaging>
   <url>http://www.qualinsight.com/</url>
   <description>Cobertura coverage report conversion to SonarQube generic coverage report format.</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jaxb2-maven-plugin</artifactId>
+        <configuration>
+          <sources>
+            <source>./src/main/resources/com/qualinsight/mojo/cobertura/transformation/sonarqube.xsd</source>
+          </sources>
+          <packageName>com.qualinsight.mojo.sonar.model</packageName>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/conversion/pom.xml
+++ b/conversion/pom.xml
@@ -10,6 +10,16 @@
   <packaging>jar</packaging>
   <url>http://www.qualinsight.com/</url>
   <description>Cobertura coverage report conversion to SonarQube generic coverage report format.</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura</artifactId>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/CoberturaToSonarQubeReportConverter.java
+++ b/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/CoberturaToSonarQubeReportConverter.java
@@ -1,0 +1,31 @@
+/*
+ * qualinsight-mojo-cobertura
+ * Copyright (c) 2015-2017, QualInsight
+ * http://www.qualinsight.com/
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program. If not, you can retrieve a copy
+ * from <http://www.gnu.org/licenses/>.
+ */
+package com.qualinsight.mojo.cobertura.transformation;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.io.File;
+
+/**
+ * @author pfrank
+ */
+public interface CoberturaToSonarQubeReportConverter {
+  void convertReport(final String[] sourcesPaths, final String projectPath) throws MojoExecutionException;
+}

--- a/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/JaxbCoberturaToSonarQubeReportConverter.java
+++ b/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/JaxbCoberturaToSonarQubeReportConverter.java
@@ -24,12 +24,15 @@ import com.qualinsight.mojo.sonar.model.FileType;
 import com.qualinsight.mojo.sonar.model.LineToCoverType;
 import com.qualinsight.mojo.sonar.model.ObjectFactory;
 
+import net.sourceforge.cobertura.coveragedata.ClassData;
+import net.sourceforge.cobertura.coveragedata.CoverageData;
 import net.sourceforge.cobertura.coveragedata.ProjectData;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
 import java.io.File;
+import java.util.Collection;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
@@ -78,17 +81,20 @@ public class JaxbCoberturaToSonarQubeReportConverter implements CoberturaToSonar
       final CoverageType coverageType = new CoverageType();
       coverageType.setVersion(1);
 
-      final FileType fileType = new FileType();
-      fileType.setPath("/my/path");
-      coverageType.setFile(fileType);
+      @SuppressWarnings("unchecked")
+      final Collection<ClassData> classData = (Collection<ClassData>) projectData.getClasses();
+      for(ClassData classDatum : classData){
+        final FileType fileType = new FileType();
+        coverageType.getFile().add(fileType);
 
-      final LineToCoverType lineToCoverType = new LineToCoverType();
-      lineToCoverType.setBranchesToCover(1);
-      lineToCoverType.setCovered("1");
-      lineToCoverType.setLineNumber(1);
-      lineToCoverType.setCoveredBranches(1);
-      lineToCoverType.setValue("1");
-      fileType.getLineToCover().add(lineToCoverType);
+        //TODO the sourceFileName against various sourcePaths to create the full path needed by sonar
+        fileType.setPath(classDatum.getSourceFileName());
+
+
+        for(CoverageData coverageData : classDatum.getLines()){
+          //pattern match for the different coverage data types to create the LineToCoverType
+        }
+      }
 
       final JAXBElement<CoverageType> coverageTypeJAXBElement = factory.createCoverage(coverageType);
       marshaller.marshal(coverageTypeJAXBElement, destinationSonarXmlFile);

--- a/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/JaxbCoberturaToSonarQubeReportConverter.java
+++ b/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/JaxbCoberturaToSonarQubeReportConverter.java
@@ -1,0 +1,59 @@
+/*
+ * qualinsight-mojo-cobertura
+ * Copyright (c) 2015-2017, QualInsight
+ * http://www.qualinsight.com/
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program. If not, you can retrieve a copy
+ * from <http://www.gnu.org/licenses/>.
+ */
+package com.qualinsight.mojo.cobertura.transformation;
+
+import net.sourceforge.cobertura.coveragedata.ProjectData;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.File;
+
+/**
+ * @author pfrank
+ */
+public class JaxbCoberturaToSonarQubeReportConverter implements CoberturaToSonarQubeReportConverter {
+  private final Log log;
+  private final ProjectData projectData;
+  private final File destinationSonarXmlFile;
+
+  public JaxbCoberturaToSonarQubeReportConverter(final Log log, final ProjectData projectData, final File destinationSonarXmlFile){
+    if(log == null){
+      throw new IllegalArgumentException("Log cannot be null");
+    }
+    if(projectData == null){
+      throw new IllegalArgumentException("ProjectData cannot be null");
+    }
+    if(destinationSonarXmlFile == null){
+      throw new IllegalArgumentException("File destinationSonarXmlFile cannot be null.");
+    }
+
+    this.log = log;
+    this.projectData = projectData;
+    this.destinationSonarXmlFile = destinationSonarXmlFile;
+  }
+
+  @Override
+  public void convertReport(
+      final String[] sourcesPaths,
+      final String projectPath) throws MojoExecutionException {
+    throw new UnsupportedOperationException("This is not supported yet");
+  }
+}

--- a/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/XslCoberturaToSonarQubeReportConverter.java
+++ b/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/XslCoberturaToSonarQubeReportConverter.java
@@ -29,6 +29,9 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerConfigurationException;
 
 /**
+ * This was refactored out before supporting multiple sourcesPaths, this will still create an cobertura xml file
+ * but the path needed to associate that data in cobertura will be incorrect
+ *
  * @author pfrank
  */
 public class XslCoberturaToSonarQubeReportConverter implements CoberturaToSonarQubeReportConverter {

--- a/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/XslCoberturaToSonarQubeReportConverter.java
+++ b/conversion/src/main/java/com/qualinsight/mojo/cobertura/transformation/XslCoberturaToSonarQubeReportConverter.java
@@ -1,0 +1,90 @@
+/*
+ * qualinsight-mojo-cobertura
+ * Copyright (c) 2015-2017, QualInsight
+ * http://www.qualinsight.com/
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program. If not, you can retrieve a copy
+ * from <http://www.gnu.org/licenses/>.
+ */
+package com.qualinsight.mojo.cobertura.transformation;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerConfigurationException;
+
+/**
+ * @author pfrank
+ */
+public class XslCoberturaToSonarQubeReportConverter implements CoberturaToSonarQubeReportConverter {
+  private final Log log;
+  private final File conversionInputFile;
+  private final File conversionOutputFile;
+
+  public XslCoberturaToSonarQubeReportConverter(final Log log, final File conversionInputFile, final File conversionOutputFile){
+    if(log == null){
+      throw new IllegalArgumentException("Log cannot be null.");
+    }
+    if(conversionInputFile == null){
+      throw new IllegalArgumentException("conversionInputFile cannot be null.");
+    }
+    if(conversionOutputFile == null){
+      throw new IllegalArgumentException("conversionOutputFile cannot be null");
+    }
+
+    this.log = log;
+    this.conversionInputFile = conversionInputFile;
+    this.conversionOutputFile = conversionOutputFile;
+  }
+
+  private Log getLog(){
+    return log;
+  }
+
+  @Override
+  public void convertReport(final String[] sourcesPaths, final String projectPath) throws MojoExecutionException {
+    getLog().debug("Converting Cobertura report to SonarQube generic test coverage report format");
+    try {
+      final String sourcesPath = sourcesPaths[0];
+      final String sourceDirectory = sourcesPath.substring(projectPath.length());
+      if (!sourceDirectory.endsWith(File.separator)) {
+        throw new MojoExecutionException("sourcesPath property must end with '" + File.separator + "' character. Stoping mojo execution.");
+      }
+      getLog().debug("XSLT SRC_DIR variable is set to: " + sourceDirectory);
+      new CoberturaToSonarQubeCoverageReportConverter(sourceDirectory).withInputFile(conversionInputFile)
+                                                                      .withOuputFile(conversionOutputFile)
+                                                                      .process();
+    } catch (final CoberturaToSonarQubeCoverageReportConversionProcessingException e) {
+      final String message = "An error occurred during coverage output conversion: ";
+      getLog().error(message, e);
+      throw new MojoExecutionException(message, e);
+    } catch (final TransformerConfigurationException e) {
+      final String message = "An error occurred during transformation configuration: ";
+      getLog().error(message, e);
+      throw new MojoExecutionException(message, e);
+    } catch (final ParserConfigurationException e) {
+      final String message = "An error occurred during parser configuration: ";
+      getLog().error(message, e);
+      throw new MojoExecutionException(message, e);
+    } catch (final IOException e) {
+      final String message = "An error occurred while trying to access conversion files: ";
+      getLog().error(message, e);
+      throw new MojoExecutionException(message, e);
+    }
+  }
+}

--- a/conversion/src/main/resources/com/qualinsight/mojo/cobertura/transformation/sonarqube.xsd
+++ b/conversion/src/main/resources/com/qualinsight/mojo/cobertura/transformation/sonarqube.xsd
@@ -21,9 +21,8 @@
 
   <xs:complexType name="coverageType">
     <xs:sequence>
-      <xs:element type="fileType" name="file"/>
+      <xs:element type="fileType" name="file" maxOccurs="unbounded" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute type="xs:int" name="version"/>
   </xs:complexType>
-
 </xs:schema>

--- a/conversion/src/main/resources/com/qualinsight/mojo/cobertura/transformation/sonarqube.xsd
+++ b/conversion/src/main/resources/com/qualinsight/mojo/cobertura/transformation/sonarqube.xsd
@@ -1,0 +1,29 @@
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="coverage" type="coverageType"/>
+
+  <xs:complexType name="lineToCoverType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:int" name="lineNumber" use="optional"/>
+        <xs:attribute type="xs:string" name="covered" use="optional"/>
+        <xs:attribute type="xs:int" name="branchesToCover" use="optional"/>
+        <xs:attribute type="xs:int" name="coveredBranches" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="fileType">
+    <xs:sequence>
+      <xs:element type="lineToCoverType" name="lineToCover" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="path"/>
+  </xs:complexType>
+
+  <xs:complexType name="coverageType">
+    <xs:sequence>
+      <xs:element type="fileType" name="file"/>
+    </xs:sequence>
+    <xs:attribute type="xs:int" name="version"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/conversion/src/main/resources/com/qualinsight/mojo/cobertura/transformation/sonarqube.xsd
+++ b/conversion/src/main/resources/com/qualinsight/mojo/cobertura/transformation/sonarqube.xsd
@@ -5,7 +5,7 @@
     <xs:simpleContent>
       <xs:extension base="xs:string">
         <xs:attribute type="xs:int" name="lineNumber" use="optional"/>
-        <xs:attribute type="xs:string" name="covered" use="optional"/>
+        <xs:attribute type="xs:boolean" name="covered" use="optional"/>
         <xs:attribute type="xs:int" name="branchesToCover" use="optional"/>
         <xs:attribute type="xs:int" name="coveredBranches" use="optional"/>
       </xs:extension>

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractCleaningReportMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractCleaningReportMojo.java
@@ -44,13 +44,12 @@ public abstract class AbstractCleaningReportMojo extends AbstractReportMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         final File dataFile = new File(dataFilePath() + AbstractInstrumentationMojo.DATA_FILE_NAME);
         final File destinationDataFile = new File(coverageReportPath() + AbstractInstrumentationMojo.DATA_FILE_NAME);
-        final File sourcesDirectory = new File(sourcesPath());
         final File destinationDirectory = new File(coverageReportPath());
         final File classesDirectory = new File(this.classesPath);
         final File backupDirectory = new File(this.backupPath);
         if (classesDirectory.exists() && classesDirectory.isDirectory()) {
             prepareFileSystem(destinationDirectory);
-            processReporting(buildCoberturaReportArguments(sourcesDirectory, destinationDirectory, dataFile));
+            processReporting(buildCoberturaReportArguments(destinationDirectory, dataFile));
             cleanupFileSystem(classesDirectory, backupDirectory, dataFile, destinationDataFile);
             convertToSonarQubeReport(CoverageDataFileHandler.loadCoverageData(destinationDataFile));
         } else {

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractCleaningReportMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractCleaningReportMojo.java
@@ -27,6 +27,8 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 import com.qualinsight.mojo.cobertura.core.instrumentation.AbstractInstrumentationMojo;
 
+import net.sourceforge.cobertura.coveragedata.CoverageDataFileHandler;
+
 public abstract class AbstractCleaningReportMojo extends AbstractReportMojo {
 
     @Parameter(defaultValue = "${project.build.directory}/classes/", required = false)
@@ -50,7 +52,7 @@ public abstract class AbstractCleaningReportMojo extends AbstractReportMojo {
             prepareFileSystem(destinationDirectory);
             processReporting(buildCoberturaReportArguments(sourcesDirectory, destinationDirectory, dataFile));
             cleanupFileSystem(classesDirectory, backupDirectory, dataFile, destinationDataFile);
-            convertToSonarQubeReport();
+            convertToSonarQubeReport(CoverageDataFileHandler.loadCoverageData(destinationDataFile));
         } else {
             getLog().info("Directory containing classes does not exist, skipping execution.");
         }

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractReportMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractReportMojo.java
@@ -70,7 +70,7 @@ public abstract class AbstractReportMojo extends AbstractMojo {
     private boolean calculateMethodComplexity;
 
     @Parameter(defaultValue = "true", required = false)
-    private final boolean useXslTransform = true;
+    private boolean useXslTransform = true;
 
     protected void prepareFileSystem(final File destinationDirectory) throws MojoExecutionException {
         getLog().debug("Preparing Cobertura report generation directories");

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractReportMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractReportMojo.java
@@ -69,8 +69,9 @@ public abstract class AbstractReportMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", required = false)
     private boolean calculateMethodComplexity;
 
-    @Parameter(defaultValue = "true", required = false)
-    private boolean useXslTransform = true;
+    //TODO remove this before merging, it's just for testing purposes in case
+    @Parameter(defaultValue = "false", required = false)
+    private boolean useXslTransform;
 
     protected void prepareFileSystem(final File destinationDirectory) throws MojoExecutionException {
         getLog().debug("Preparing Cobertura report generation directories");
@@ -141,11 +142,10 @@ public abstract class AbstractReportMojo extends AbstractMojo {
 
     abstract String coverageReportPath();
 
-    Arguments buildCoberturaReportArguments(final File sourcesDirectory, final File destinationDirectory, final File dataFile) {
+    Arguments buildCoberturaReportArguments(final File destinationDirectory, final File dataFile) {
         getLog().debug("Building Cobertura report generation arguments");
         final ArgumentsBuilder builder = new ArgumentsBuilder();
-        builder.setBaseDirectory(sourcesDirectory.getAbsolutePath())
-            .setDestinationDirectory(destinationDirectory.getAbsolutePath())
+        builder.setDestinationDirectory(destinationDirectory.getAbsolutePath())
             .setDataFile(dataFile.getAbsolutePath())
             .setEncoding(encoding())
             .calculateMethodComplexity(this.calculateMethodComplexity);

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractReportMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/AbstractReportMojo.java
@@ -52,6 +52,9 @@ public abstract class AbstractReportMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.basedir}/src/main/java/", required = false)
     private String sourcesPath;
 
+    @Parameter(defaultValue = "${project.basedir}/src/main/java/", required = false)
+    private String[] sourcesPaths;
+
     @Parameter(defaultValue = "UTF-8", required = false)
     private String encoding;
 
@@ -139,6 +142,10 @@ public abstract class AbstractReportMojo extends AbstractMojo {
         return this.sourcesPath;
     }
 
+    protected String[] sourcesPaths(){
+        return this.sourcesPaths;
+    }
+
     protected String encoding() {
         return this.encoding;
     }
@@ -152,13 +159,21 @@ public abstract class AbstractReportMojo extends AbstractMojo {
     Arguments buildCoberturaReportArguments(final File sourcesDirectory, final File destinationDirectory, final File dataFile) {
         getLog().debug("Building Cobertura report generation arguments");
         final ArgumentsBuilder builder = new ArgumentsBuilder();
-        return builder.setBaseDirectory(sourcesDirectory.getAbsolutePath())
+        builder.setBaseDirectory(sourcesDirectory.getAbsolutePath())
             .setDestinationDirectory(destinationDirectory.getAbsolutePath())
             .setDataFile(dataFile.getAbsolutePath())
             .setEncoding(encoding())
-            .calculateMethodComplexity(this.calculateMethodComplexity)
-            .addSources(sourcesPath, true)
-            .build();
+            .calculateMethodComplexity(this.calculateMethodComplexity);
+
+        if(sourcesPaths != null && sourcesPaths.length > 0) {
+            for (String sourcesPath : sourcesPaths) {
+                builder.addSources(sourcesPath, true);
+            }
+        }else{
+            builder.addSources(this.sourcesPath, true);
+        }
+
+        return builder.build();
     }
 
 }

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/OverallCoverageReportMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/OverallCoverageReportMojo.java
@@ -20,6 +20,8 @@
 package com.qualinsight.mojo.cobertura.core.reporting;
 
 import java.io.File;
+
+import net.sourceforge.cobertura.coveragedata.CoverageDataFileHandler;
 import net.sourceforge.cobertura.dsl.Arguments;
 import net.sourceforge.cobertura.dsl.ArgumentsBuilder;
 import net.sourceforge.cobertura.dsl.Cobertura;
@@ -58,7 +60,7 @@ public class OverallCoverageReportMojo extends AbstractReportMojo {
             prepareFileSystem(overallCoverageDirectory);
             processMerging(buildMergingArguments(utCoverageDataFile, itCoverageDataFile, overallCoverageDirectory, overallCoverageDataFile));
             processReporting(buildCoberturaReportArguments(sourcesDirectory, overallCoverageDirectory, overallCoverageDataFile));
-            convertToSonarQubeReport();
+            convertToSonarQubeReport(CoverageDataFileHandler.loadCoverageData(overallCoverageDataFile));
         } else {
             getLog().info("UT and/or IT coverage data file does not exist, skipping execution.");
         }

--- a/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/OverallCoverageReportMojo.java
+++ b/core/src/main/java/com/qualinsight/mojo/cobertura/core/reporting/OverallCoverageReportMojo.java
@@ -51,7 +51,6 @@ public class OverallCoverageReportMojo extends AbstractReportMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        final File sourcesDirectory = new File(sourcesPath());
         final File overallCoverageDirectory = new File(coverageReportPath());
         final File utCoverageDataFile = new File(this.utCoverageDataFileLocation);
         final File itCoverageDataFile = new File(this.itCoverageDataFileLocation);
@@ -59,7 +58,7 @@ public class OverallCoverageReportMojo extends AbstractReportMojo {
         if (utCoverageDataFile.exists() && utCoverageDataFile.isFile() && itCoverageDataFile.exists() && itCoverageDataFile.isFile()) {
             prepareFileSystem(overallCoverageDirectory);
             processMerging(buildMergingArguments(utCoverageDataFile, itCoverageDataFile, overallCoverageDirectory, overallCoverageDataFile));
-            processReporting(buildCoberturaReportArguments(sourcesDirectory, overallCoverageDirectory, overallCoverageDataFile));
+            processReporting(buildCoberturaReportArguments(overallCoverageDirectory, overallCoverageDataFile));
             convertToSonarQubeReport(CoverageDataFileHandler.loadCoverageData(overallCoverageDataFile));
         } else {
             getLog().info("UT and/or IT coverage data file does not exist, skipping execution.");

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <lib.version.maven-plugin-annotations>3.4</lib.version.maven-plugin-annotations>
     <lib.version.commons-io>2.4</lib.version.commons-io>
     <lib.version.maven-project>2.2.1</lib.version.maven-project>
+    <lib.version.jaxb2-maven-plugin>2.3.1</lib.version.jaxb2-maven-plugin>
     <!-- License properties -->
     <license.name>QualInsight-LGPL3</license.name>
     <license.project>qualinsight-mojo-cobertura</license.project>
@@ -95,6 +96,23 @@
     <module>conversion</module>
   </modules>
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>jaxb2-maven-plugin</artifactId>
+          <version>${lib.version.jaxb2-maven-plugin}</version>
+          <executions>
+            <execution>
+              <id>xjc</id>
+              <goals>
+                <goal>xjc</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…Cobertura ArgumentBuilder.

E.g.
            <sourcesPaths>
              <scourcesPath>${project.basedir}/src/main/groovy/</scourcesPath>
              <scourcesPath>${project.basedir}/src/main/java/</scourcesPath>
            </sourcesPaths>
Adds support for both groovy files and java files in a GMavenPlus Plugin default layout.